### PR TITLE
Add missing bibliography

### DIFF
--- a/doc/make_doc
+++ b/doc/make_doc
@@ -2,8 +2,8 @@
 set -e
 
 echo "TeXing documentation"
-# TeX the manual
-tex manual
+# TeX the manual and build its bibliography
+tex manual; bibtex manual
 # TeX the manual again to incorporate the ToC ... and build the index
 tex manual; ../../../doc/manualindex manual
 # Finally TeX the manual again to get cross-references right

--- a/doc/manual.bib
+++ b/doc/manual.bib
@@ -1,0 +1,61 @@
+@Article{CH,
+  author  = {Roger W. Carter and Trevor O. Hawkes},
+  title   = {The {$\cal F$}-normalizers of a finite soluble group},
+  journal = {Journal of Algebra},
+  volume  = 5,
+  number  = 2,
+  pages   = {175--202},
+  month   = feb,
+  year    = 1967
+}
+
+@Book{DH,
+  author    = {Klaus Doerk and Trevor O. Hawkes},
+  title     = {Finite soluble groups},
+  publisher = {Walter de Gruyter},
+  year      = 1992,
+  series    = {De Gruyter Expositions in Mathematics}
+}
+
+@Article{EW,
+  author  = {Bettina Eick and Charles R. B. Wright},
+  title   = {Computing subgroups by exhibition in finite solvable groups},
+  journal = {Journal of Symbolic Computation},
+  volume  = 33,
+  number  = 2,
+  pages   = {129--43},
+  month   = feb,
+  year    = 2002
+}
+
+@Article{G,
+  author  = {Wolfgang Gasch\"utz},
+  title   = {Zur Theorie der endlichen aufl\"osbaren Gruppen},
+  journal = {Mathematische Zeitschrift},
+  volume  = 80,
+  number  = 1,
+  pages   = {300--5},
+  month   = dec,
+  year    = 1963
+}
+
+@Article{WA,
+  author  = {Charles R. B. Wright},
+  title   = {An internal approach to covering groups},
+  journal = {Journal of Algebra},
+  volume  = 25,
+  number  = 1,
+  pages   = {128--45},
+  month   = apr,
+  year    = 1973
+}
+
+@Article{WB,
+  author  = {Charles R. B. Wright},
+  title   = {On internal formation theory},
+  journal = {Mathematische Zeitschrift},
+  volume  = 134,
+  pages   = {1--9},
+  month   = mar,
+  year    = 1973
+}


### PR DESCRIPTION
Resolves https://github.com/gap-packages/format/issues/7.  I found the bib file in the 1.1 release tarball.  I have enhanced it somewhat.  For example, one paper was "to appear"; that entry was updated to reflects its actual appearance.  Also, I dislike abbreviations in BibTeX files.  I prefer to spell everything out, and let the style choose what to abbreviate, or omit.